### PR TITLE
Fix newline handling when parsing subsense lists

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -943,17 +943,28 @@ def text_fn(ctx: "Wtp", token: str) -> None:
                     node.children.append(token)
                     return
                 _parser_merge_str_children(ctx)
-                if (
-                    node.children
-                    and isinstance(node.children[-1], str)
-                    and (
-                        len(node.children) > 1
-                        or not node.children[-1].isspace()
-                    )
-                    and node.children[-1].endswith("\n")
-                ):
-                    _parser_pop(ctx, False)
-                    continue
+                if node.children and isinstance(node.children[-1], str):
+                    if len(node.children) == 1 and node.children[-1].isspace():
+                        pass
+                    else:
+                        trailing_newlines = 0
+                        idx = len(node.children) - 1
+                        while idx >= 0:
+                            child = node.children[idx]
+                            if not isinstance(child, str):
+                                break
+                            stripped = child.rstrip(" \t")
+                            without_newlines = stripped.rstrip("\n")
+                            trailing_newlines += len(stripped) - len(without_newlines)
+                            if trailing_newlines >= 2:
+                                break
+                            if without_newlines:
+                                break
+                            idx -= 1
+
+                        if trailing_newlines >= 2:
+                            _parser_pop(ctx, False)
+                            continue
             elif node.kind == NodeKind.LIST:
                 _parser_pop(ctx, False)
                 continue

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -228,6 +228,39 @@ dasfasddasfdas
         tree = self.parse("test", "{{x}<nowiki />}")
         self.assertEqual(tree.children, ["&lbrace;&lbrace;x&rbrace;&rbrace;"])
 
+    def test_subsense_examples_stay_nested(self):
+        text = """# {{lb|en|intransitive}}
+## To produce and deposit an egg or eggs.
+##* {{quote-book|passage=It lays well.}}
+##* {{quote-book|passage=It lays more.}}
+##* {{quote-book|passage=It lays again.}}
+##* {{quote-book|passage=It lays once more.}}
+##* {{quote-book|passage=It lays yet again.}}
+"""
+
+        tree = self.parse("lay", text)
+        outer_list = tree.children[0]
+        self.assertEqual(outer_list.kind, NodeKind.LIST)
+        wrapper_item = outer_list.children[0]
+        self.assertEqual(wrapper_item.kind, NodeKind.LIST_ITEM)
+        subsense_lists = [
+            child
+            for child in wrapper_item.children
+            if isinstance(child, WikiNode) and child.kind == NodeKind.LIST
+        ]
+        self.assertEqual(len(subsense_lists), 1)
+        subsense_item = subsense_lists[0].children[0]
+        self.assertEqual(subsense_item.kind, NodeKind.LIST_ITEM)
+        nested_lists = [
+            child
+            for child in subsense_item.children
+            if isinstance(child, WikiNode) and child.kind == NodeKind.LIST
+        ]
+        self.assertEqual(len(nested_lists), 1)
+        examples_list = nested_lists[0]
+        self.assertEqual(examples_list.kind, NodeKind.LIST)
+        self.assertEqual(len(examples_list.children), 5)
+
     def test_nowiki17(self):
         tree = self.parse("test", "{{x<nowiki />}}")
         self.assertEqual(


### PR DESCRIPTION
## Summary
- adjust the parser's text handler to keep subsense list items on the stack when only a single trailing newline is seen
- add a regression test ensuring nested example bullets remain under their subsense entry

## Testing
- PYTHONPATH=src pytest tests/test_parser.py::ParserTests::test_subsense_examples_stay_nested


------
https://chatgpt.com/codex/tasks/task_e_68e3f86deeb483318ccf2fe2b5847107