### PR TITLE
Add optional import debug print

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Python's unittest framework help and options can be accessed through:
 python -m unittest -h
 ```
 
+### Debugging imports
+
+If you need to confirm that a local checkout of `wikitextprocessor` is the one
+being imported (for example, while testing `wiktextract`), set the environment
+variable `WTP_DEBUG_IMPORT=1` before running your script or CLI. When the
+package is imported, it will print a message showing the path of the
+`wikitextprocessor.__init__` module that was loaded along with the Python
+version.
+
 ### Obtaining WikiMedia dump files
 
 This package is primarily intended for processing Wiktionary and

--- a/src/wikitextprocessor/__init__.py
+++ b/src/wikitextprocessor/__init__.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import os
+import sys
+
 from .common import MAGIC_FIRST, MAGIC_LAST
 from .core import Page, TemplateArgs, Wtp
 from .parser import HTMLNode, LevelNode, NodeKind, TemplateNode, WikiNode
@@ -14,3 +19,13 @@ __all__ = (
     "Page",
     "TemplateArgs",
 )
+
+if os.environ.get("WTP_DEBUG_IMPORT"):
+    print(
+        "[wikitextprocessor] imported __init__ from",
+        __file__,
+        "(python",
+        ".".join(map(str, sys.version_info[:3])),
+        ")",
+        flush=True,
+    )


### PR DESCRIPTION
## Summary
- add an environment-variable controlled print in wikitextprocessor.__init__ to confirm which package instance is imported
- document the new WTP_DEBUG_IMPORT helper in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8016d24148331be9433bb40ff6159